### PR TITLE
Add analytics dashboard with data service

### DIFF
--- a/analytics.json
+++ b/analytics.json
@@ -1,0 +1,120 @@
+{
+  "generatedAt": "2025-02-10T08:30:00Z",
+  "metrics": {
+    "visits": 18240,
+    "visitsChange": 12.4,
+    "sales": 4875.6,
+    "salesChange": 9.3,
+    "orders": 642,
+    "ordersChange": 7.8,
+    "conversionRate": 3.5,
+    "conversionChange": 0.6,
+    "avgOrderValue": 7.6,
+    "aovChange": 1.1
+  },
+  "dailyTrends": [
+    { "date": "2025-01-28", "label": "٢٨ يناير", "visits": 1180, "orders": 38, "sales": 285.4 },
+    { "date": "2025-01-29", "label": "٢٩ يناير", "visits": 1215, "orders": 40, "sales": 296.8 },
+    { "date": "2025-01-30", "label": "٣٠ يناير", "visits": 1230, "orders": 42, "sales": 310.2 },
+    { "date": "2025-01-31", "label": "٣١ يناير", "visits": 1255, "orders": 44, "sales": 324.7 },
+    { "date": "2025-02-01", "label": "١ فبراير", "visits": 1280, "orders": 45, "sales": 333.0 },
+    { "date": "2025-02-02", "label": "٢ فبراير", "visits": 1305, "orders": 46, "sales": 340.5 },
+    { "date": "2025-02-03", "label": "٣ فبراير", "visits": 1340, "orders": 48, "sales": 356.2 },
+    { "date": "2025-02-04", "label": "٤ فبراير", "visits": 1375, "orders": 49, "sales": 364.9 },
+    { "date": "2025-02-05", "label": "٥ فبراير", "visits": 1390, "orders": 50, "sales": 372.3 },
+    { "date": "2025-02-06", "label": "٦ فبراير", "visits": 1415, "orders": 52, "sales": 384.0 },
+    { "date": "2025-02-07", "label": "٧ فبراير", "visits": 1440, "orders": 53, "sales": 392.6 },
+    { "date": "2025-02-08", "label": "٨ فبراير", "visits": 1485, "orders": 55, "sales": 407.8 },
+    { "date": "2025-02-09", "label": "٩ فبراير", "visits": 1520, "orders": 57, "sales": 421.4 },
+    { "date": "2025-02-10", "label": "١٠ فبراير", "visits": 1555, "orders": 58, "sales": 435.9 }
+  ],
+  "trafficSources": [
+    { "name": "حملات إنستغرام", "sessions": 7200, "share": 42 },
+    { "name": "إعلانات تيك توك", "sessions": 4800, "share": 28 },
+    { "name": "إحالات العملاء", "sessions": 2600, "share": 15 },
+    { "name": "البحث العضوي", "sessions": 1800, "share": 10 },
+    { "name": "القائمة البريدية", "sessions": 840, "share": 5 }
+  ],
+  "recentOrders": [
+    {
+      "id": "ORD-20250210-001",
+      "customer": "سارة المطيري",
+      "package": "Instagram - باقة الاكسبلور",
+      "total": 15,
+      "status": "مكتمل",
+      "statusCode": "completed",
+      "date": "١٠ فبراير ٢٠٢٥",
+      "source": "حملات إنستغرام"
+    },
+    {
+      "id": "ORD-20250209-004",
+      "customer": "عبدالله السالم",
+      "package": "TikTok - باقة الانتشار الاقوى",
+      "total": 10,
+      "status": "قيد المراجعة",
+      "statusCode": "processing",
+      "date": "٩ فبراير ٢٠٢٥",
+      "source": "إعلانات تيك توك"
+    },
+    {
+      "id": "ORD-20250209-002",
+      "customer": "منى الدوسري",
+      "package": "Snapchat - 1,000 متابع",
+      "total": 25,
+      "status": "قيد التنفيذ",
+      "statusCode": "processing",
+      "date": "٩ فبراير ٢٠٢٥",
+      "source": "إحالات العملاء"
+    },
+    {
+      "id": "ORD-20250208-003",
+      "customer": "شركة النور",
+      "package": "YouTube - 4,000 ساعة مشاهدة",
+      "total": 30,
+      "status": "مكتمل",
+      "statusCode": "completed",
+      "date": "٨ فبراير ٢٠٢٥",
+      "source": "القائمة البريدية"
+    },
+    {
+      "id": "ORD-20250207-006",
+      "customer": "حسين العجمي",
+      "package": "Instagram - 10,000 متابع",
+      "total": 8,
+      "status": "ملغي",
+      "statusCode": "cancelled",
+      "date": "٧ فبراير ٢٠٢٥",
+      "source": "حملات إنستغرام"
+    },
+    {
+      "id": "ORD-20250207-002",
+      "customer": "نورة السهلي",
+      "package": "TikTok - الباقة المليونية",
+      "total": 20,
+      "status": "مكتمل",
+      "statusCode": "completed",
+      "date": "٧ فبراير ٢٠٢٥",
+      "source": "إعلانات تيك توك"
+    },
+    {
+      "id": "ORD-20250206-005",
+      "customer": "استوديو سما",
+      "package": "Instagram - 1,000 مشاهدات لايف",
+      "total": 5,
+      "status": "مكتمل",
+      "statusCode": "completed",
+      "date": "٦ فبراير ٢٠٢٥",
+      "source": "البحث العضوي"
+    },
+    {
+      "id": "ORD-20250205-003",
+      "customer": "بدر الفهد",
+      "package": "Twitter - 10,000 لايك",
+      "total": 6,
+      "status": "قيد المراجعة",
+      "statusCode": "pending",
+      "date": "٥ فبراير ٢٠٢٥",
+      "source": "إحالات العملاء"
+    }
+  ]
+}

--- a/index.htmll
+++ b/index.htmll
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, createContext, useContext, forwardRef } from 'react';
+import React, { useState, useEffect, createContext, useContext, forwardRef, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ArrowLeft, Star, Users, Zap, Menu, X, Shield, Clock, Headphones as HeadphonesIcon, CreditCard, Instagram, Facebook, Youtube, Twitter, MessageCircle, Quote, Mail, Phone, MapPin, ShoppingCart, Globe, CheckCircle, Gift } from 'lucide-react';
 import { clsx } from 'clsx';
@@ -6,6 +6,7 @@ import { twMerge } from 'tailwind-merge';
 import * as ToastPrimitives from '@radix-ui/react-toast';
 import { cva } from 'class-variance-authority';
 import * as TabsPrimitive from "@radix-ui/react-tabs";
+import { ResponsiveContainer, AreaChart, Area, CartesianGrid, XAxis, YAxis, Tooltip } from 'recharts';
 
 // Helper: cn (for merging Tailwind classes)
 function cn(...inputs) {
@@ -17,6 +18,32 @@ const handleScroll = (id) => {
     const element = document.getElementById(id);
     if (element) {
         element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+};
+
+const ANALYTICS_STORAGE_KEY = 'boostly-analytics';
+
+const getStoredAnalytics = () => {
+    if (typeof window === 'undefined') {
+        return null;
+    }
+    try {
+        const stored = window.localStorage.getItem(ANALYTICS_STORAGE_KEY);
+        return stored ? JSON.parse(stored) : null;
+    } catch (error) {
+        console.error('فشل في قراءة بيانات التحليلات من التخزين المحلي', error);
+        return null;
+    }
+};
+
+const setStoredAnalytics = (analytics) => {
+    if (typeof window === 'undefined') {
+        return;
+    }
+    try {
+        window.localStorage.setItem(ANALYTICS_STORAGE_KEY, JSON.stringify(analytics));
+    } catch (error) {
+        console.error('فشل في حفظ بيانات التحليلات في التخزين المحلي', error);
     }
 };
 
@@ -189,11 +216,12 @@ TabsContent.displayName = TabsPrimitive.Content.displayName;
 const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const navItems = [
-      { name: 'الرئيسية', id: 'hero' }, 
-      { name: 'الباقات الأكثر طلباً', id: 'featured-packages' }, 
-      { name: 'جميع الباقات', id: 'pricing' }, 
-      { name: 'خدماتنا', id: 'services' }, 
-      { name: 'آراء العملاء', id: 'testimonials' }, 
+      { name: 'الرئيسية', id: 'hero' },
+      { name: 'الباقات الأكثر طلباً', id: 'featured-packages' },
+      { name: 'جميع الباقات', id: 'pricing' },
+      { name: 'خدماتنا', id: 'services' },
+      { name: 'لوحة التحكم', id: 'dashboard' },
+      { name: 'آراء العملاء', id: 'testimonials' },
       { name: 'اتصل بنا', id: 'contact' }
     ];
 
@@ -291,6 +319,14 @@ const FeaturedPackages = () => {
     const handlePlanSelect = (platform, planName, price) => {
         const message = `أهلاً Boostly،\n\nأود طلب الباقة التالية:\n- المنصة: *${platform}*\n- الباقة: *${planName}*\n- السعر: *${price}*\n\nالرجاء تأكيد الطلب.`;
         const encodedMessage = encodeURIComponent(message);
+        if (typeof window !== 'undefined' && window.boostlyAnalytics?.recordOrder) {
+            window.boostlyAnalytics.recordOrder({
+                platform,
+                packageName: planName,
+                price,
+                source: 'الباقات الأكثر طلباً'
+            });
+        }
         window.open(`https://wa.me/96560930205?text=${encodedMessage}`, '_blank');
     };
 
@@ -369,6 +405,373 @@ const Services = () => {
     );
 };
 
+const Dashboard = () => {
+    const [analytics, setAnalytics] = useState(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    const loadAnalytics = useCallback(async (forceRemote = false) => {
+        if (typeof window === 'undefined') {
+            return null;
+        }
+
+        const stored = getStoredAnalytics();
+        if (!forceRemote && stored) {
+            return stored;
+        }
+
+        const response = await fetch('/analytics.json', { cache: 'no-store' });
+        if (!response.ok) {
+            throw new Error('تعذر تحميل ملف التحليلات');
+        }
+        const data = await response.json();
+
+        const mergeDailyTrends = (primary = [], secondary = []) => {
+            const map = new Map();
+            (primary || []).forEach((item) => {
+                if (!item?.date) return;
+                map.set(item.date, { ...item });
+            });
+            (secondary || []).forEach((item) => {
+                if (!item?.date) return;
+                const existing = map.get(item.date);
+                if (existing) {
+                    existing.visits = Math.max(existing.visits ?? 0, item.visits ?? 0);
+                    existing.orders = Math.max(existing.orders ?? 0, item.orders ?? 0);
+                    existing.sales = Math.max(existing.sales ?? 0, item.sales ?? 0);
+                    if (!existing.label && item.label) {
+                        existing.label = item.label;
+                    }
+                } else {
+                    map.set(item.date, { ...item });
+                }
+            });
+            return Array.from(map.values())
+                .sort((a, b) => new Date(a.date) - new Date(b.date))
+                .slice(-14);
+        };
+
+        if (stored) {
+            const mergedMetrics = {
+                ...(data.metrics || {}),
+                ...(stored.metrics || {})
+            };
+
+            if (data.metrics || stored.metrics) {
+                mergedMetrics.visits = Math.max(data.metrics?.visits ?? 0, stored.metrics?.visits ?? 0);
+                mergedMetrics.orders = Math.max(data.metrics?.orders ?? 0, stored.metrics?.orders ?? 0);
+                mergedMetrics.sales = Math.max(data.metrics?.sales ?? 0, stored.metrics?.sales ?? 0);
+                mergedMetrics.avgOrderValue = Math.max(data.metrics?.avgOrderValue ?? 0, stored.metrics?.avgOrderValue ?? 0);
+                mergedMetrics.conversionRate = Math.max(data.metrics?.conversionRate ?? 0, stored.metrics?.conversionRate ?? 0);
+                mergedMetrics.visitsChange = data.metrics?.visitsChange ?? stored.metrics?.visitsChange;
+                mergedMetrics.ordersChange = data.metrics?.ordersChange ?? stored.metrics?.ordersChange;
+                mergedMetrics.salesChange = data.metrics?.salesChange ?? stored.metrics?.salesChange;
+                mergedMetrics.conversionChange = data.metrics?.conversionChange ?? stored.metrics?.conversionChange;
+                mergedMetrics.aovChange = data.metrics?.aovChange ?? stored.metrics?.aovChange;
+            }
+
+            data.metrics = mergedMetrics;
+
+            if (stored.recentOrders?.length) {
+                const existingIds = new Set((data.recentOrders || []).map((order) => order.id));
+                const mergedOrders = [
+                    ...stored.recentOrders.filter((order) => order && !existingIds.has(order.id)),
+                    ...(data.recentOrders || [])
+                ];
+                data.recentOrders = mergedOrders.slice(0, 8);
+            }
+
+            if (stored.dailyTrends?.length) {
+                data.dailyTrends = mergeDailyTrends(data.dailyTrends, stored.dailyTrends);
+            }
+        }
+
+        setStoredAnalytics(data);
+        return data;
+    }, []);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        const bootstrap = async () => {
+            setLoading(true);
+            setError(null);
+            try {
+                const data = await loadAnalytics();
+                if (!cancelled && data) {
+                    setAnalytics(data);
+                }
+            } catch (err) {
+                console.error(err);
+                if (!cancelled) {
+                    const fallback = getStoredAnalytics();
+                    if (fallback) {
+                        setAnalytics(fallback);
+                    }
+                    setError('تعذر تحميل بيانات التحليلات حالياً.');
+                }
+            } finally {
+                if (!cancelled) {
+                    setLoading(false);
+                }
+            }
+        };
+
+        bootstrap();
+
+        const handleUpdate = (event) => {
+            const detail = event?.detail;
+            const nextAnalytics = detail
+                ? JSON.parse(JSON.stringify(detail))
+                : getStoredAnalytics();
+
+            if (!cancelled && nextAnalytics) {
+                setAnalytics(nextAnalytics);
+            }
+        };
+
+        window.addEventListener('analytics-updated', handleUpdate);
+        window.addEventListener('storage', handleUpdate);
+
+        return () => {
+            cancelled = true;
+            window.removeEventListener('analytics-updated', handleUpdate);
+            window.removeEventListener('storage', handleUpdate);
+        };
+    }, [loadAnalytics]);
+
+    const handleRefresh = async () => {
+        try {
+            setLoading(true);
+            setError(null);
+            const data = await loadAnalytics(true);
+            if (data) {
+                setAnalytics(data);
+            }
+        } catch (err) {
+            console.error(err);
+            setError('لم نتمكن من تحديث البيانات الآن.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const formatNumber = (value) => {
+        if (typeof value !== 'number') return '—';
+        return value.toLocaleString('ar-EG');
+    };
+
+    const formatCurrency = (value) => {
+        if (typeof value !== 'number') return '—';
+        return new Intl.NumberFormat('ar-EG', {
+            style: 'currency',
+            currency: 'KWD',
+            minimumFractionDigits: 2
+        }).format(value);
+    };
+
+    const getChangeBadge = (change) => {
+        if (typeof change !== 'number') return { label: '—', color: 'text-gray-300' };
+        const sign = change > 0 ? '+' : '';
+        const color = change >= 0 ? 'text-emerald-400' : 'text-rose-400';
+        return { label: `${sign}${change.toFixed(1)}%`, color };
+    };
+
+    const metricCards = [
+        {
+            key: 'visits',
+            label: 'إجمالي الزيارات',
+            value: analytics?.metrics?.visits ?? 0,
+            change: analytics?.metrics?.visitsChange,
+            icon: Globe,
+            formatter: formatNumber
+        },
+        {
+            key: 'orders',
+            label: 'إجمالي الطلبات',
+            value: analytics?.metrics?.orders ?? 0,
+            change: analytics?.metrics?.ordersChange,
+            icon: ShoppingCart,
+            formatter: formatNumber
+        },
+        {
+            key: 'sales',
+            label: 'إجمالي المبيعات',
+            value: analytics?.metrics?.sales ?? 0,
+            change: analytics?.metrics?.salesChange,
+            icon: CreditCard,
+            formatter: formatCurrency
+        },
+        {
+            key: 'conversionRate',
+            label: 'معدل التحويل',
+            value: analytics?.metrics?.conversionRate ?? 0,
+            change: analytics?.metrics?.conversionChange,
+            icon: CheckCircle,
+            formatter: (value) => `${value?.toFixed ? value.toFixed(1) : value}%`
+        },
+        {
+            key: 'avgOrderValue',
+            label: 'متوسط قيمة الطلب',
+            value: analytics?.metrics?.avgOrderValue ?? 0,
+            change: analytics?.metrics?.aovChange,
+            icon: Gift,
+            formatter: formatCurrency
+        }
+    ];
+
+    const dailyTrends = analytics?.dailyTrends ?? [];
+    const trafficSources = analytics?.trafficSources ?? [];
+    const recentOrders = analytics?.recentOrders ?? [];
+
+    return (
+        <section id="dashboard" className="py-20 px-4 bg-white/5">
+            <div className="container mx-auto">
+                <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-6 mb-12">
+                    <div>
+                        <h2 className="text-4xl lg:text-5xl font-bold mb-4"><span className="gradient-text">لوحة التحكم</span> التحليلية</h2>
+                        <p className="text-xl text-gray-200 max-w-3xl">تابع مؤشرات الأداء الرئيسية، تطور الزيارات اليومية، وآخر الطلبات التي تم إنشاؤها من خلال الموقع.</p>
+                    </div>
+                    <div className="flex items-center gap-3 self-start lg:self-auto">
+                        <Button onClick={handleRefresh} className="btn-primary px-6 py-3">تحديث البيانات</Button>
+                        {loading && <span className="text-sm text-gray-300">جارِ التحديث...</span>}
+                    </div>
+                </div>
+
+                {error && (
+                    <div className="dashboard-alert text-sm md:text-base mb-10">
+                        {error}
+                    </div>
+                )}
+
+                {loading && !analytics ? (
+                    <div className="dashboard-loading">جارِ تحميل بيانات لوحة التحكم...</div>
+                ) : (
+                    <div className="space-y-12">
+                        <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-5">
+                            {metricCards.map((metric) => {
+                                const Icon = metric.icon;
+                                const { label, color } = getChangeBadge(metric.change);
+                                return (
+                                    <div key={metric.key} className="metric-card">
+                                        <div className="flex items-center justify-between mb-6">
+                                            <div className="metric-icon">
+                                                <Icon className="h-6 w-6" />
+                                            </div>
+                                            <span className={cn('text-sm font-medium', color)}>{label}</span>
+                                        </div>
+                                        <span className="text-sm text-gray-300 block mb-2">{metric.label}</span>
+                                        <span className="text-3xl font-bold text-white">{metric.formatter(metric.value)}</span>
+                                    </div>
+                                );
+                            })}
+                        </div>
+
+                        <div className="grid gap-8 xl:grid-cols-3">
+                            <div className="xl:col-span-2 dashboard-panel">
+                                <div className="flex items-center justify-between mb-6">
+                                    <div>
+                                        <h3 className="text-xl font-bold text-white mb-2">الاتجاه اليومي للزيارات والطلبات</h3>
+                                        <p className="text-sm text-gray-300">مخطط تراكمي يوضح تطور الأداء خلال آخر 14 يوماً.</p>
+                                    </div>
+                                </div>
+                                <div className="h-72">
+                                    <ResponsiveContainer width="100%" height="100%">
+                                        <AreaChart data={dailyTrends} margin={{ top: 10, right: 20, left: 0, bottom: 0 }}>
+                                            <defs>
+                                                <linearGradient id="colorVisits" x1="0" y1="0" x2="0" y2="1">
+                                                    <stop offset="5%" stopColor="#8851a5" stopOpacity={0.8} />
+                                                    <stop offset="95%" stopColor="#8851a5" stopOpacity={0} />
+                                                </linearGradient>
+                                                <linearGradient id="colorOrders" x1="0" y1="0" x2="0" y2="1">
+                                                    <stop offset="5%" stopColor="#e462a2" stopOpacity={0.8} />
+                                                    <stop offset="95%" stopColor="#e462a2" stopOpacity={0} />
+                                                </linearGradient>
+                                            </defs>
+                                            <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
+                                            <XAxis dataKey="label" stroke="#cbd5f5" tickLine={false} axisLine={false} />
+                                            <YAxis stroke="#cbd5f5" tickLine={false} axisLine={false} tickFormatter={(value) => value.toLocaleString('ar-EG')} />
+                                            <Tooltip contentStyle={{ backgroundColor: '#1f153f', border: '1px solid rgba(255,255,255,0.1)', borderRadius: '12px' }} />
+                                            <Area type="monotone" dataKey="visits" name="الزيارات" stroke="#8851a5" fill="url(#colorVisits)" strokeWidth={2} />
+                                            <Area type="monotone" dataKey="orders" name="الطلبات" stroke="#e462a2" fill="url(#colorOrders)" strokeWidth={2} />
+                                        </AreaChart>
+                                    </ResponsiveContainer>
+                                </div>
+                            </div>
+                            <div className="dashboard-panel">
+                                <h3 className="text-xl font-bold text-white mb-4">أفضل مصادر الزيارات</h3>
+                                <p className="text-sm text-gray-300 mb-6">تفاصيل القنوات التي تولد أكبر عدد من الجلسات المحولة.</p>
+                                <div className="space-y-4">
+                                    {trafficSources.length === 0 && (
+                                        <p className="text-sm text-gray-300">لم يتم تسجيل مصادر زيارات بعد، ستظهر البيانات هنا بمجرد توفرها.</p>
+                                    )}
+                                    {trafficSources.map((source) => (
+                                        <div key={source.name} className="traffic-source">
+                                            <div className="flex items-center justify-between mb-2">
+                                                <span className="font-medium text-white">{source.name}</span>
+                                                <span className="text-sm text-gray-300">{formatNumber(source.sessions)} زيارة</span>
+                                            </div>
+                                            <div className="traffic-progress">
+                                                <div className="traffic-progress-bar" style={{ width: `${source.share}%` }} />
+                                            </div>
+                                            <span className="text-xs text-gray-400">حصة {source.share}% من إجمالي الزيارات</span>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        </div>
+
+                        <div className="dashboard-panel">
+                            <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
+                                <div>
+                                    <h3 className="text-xl font-bold text-white mb-2">الطلبات الحديثة</h3>
+                                    <p className="text-sm text-gray-300">آخر الطلبات الواردة عبر الموقع مع حالتها الحالية.</p>
+                                </div>
+                                <span className="text-sm text-gray-300">يتم التحديث عند إنشاء طلب جديد.</span>
+                            </div>
+                            <div className="overflow-x-auto">
+                                <table className="dashboard-table">
+                                    <thead>
+                                        <tr>
+                                            <th>رقم الطلب</th>
+                                            <th>العميل</th>
+                                            <th>الباقة</th>
+                                            <th>القيمة</th>
+                                            <th>الحالة</th>
+                                            <th>التاريخ</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {recentOrders.length === 0 && (
+                                            <tr>
+                                                <td colSpan={6} className="text-center text-gray-300 py-6">لا توجد طلبات مسجلة حتى الآن.</td>
+                                            </tr>
+                                        )}
+                                        {recentOrders.map((order) => (
+                                            <tr key={order.id}>
+                                                <td>{order.id}</td>
+                                                <td>{order.customer}</td>
+                                                <td>{order.package}</td>
+                                                <td>{formatCurrency(order.total)}</td>
+                                                <td>
+                                                    <span className={cn('status-badge', `status-${order.statusCode || 'pending'}`)}>
+                                                        {order.status}
+                                                    </span>
+                                                </td>
+                                                <td>{order.date}</td>
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                )}
+            </div>
+        </section>
+    );
+};
+
 const Pricing = () => {
     const pricingData = {
         instagram: [
@@ -397,6 +800,14 @@ const Pricing = () => {
     const handlePlanSelect = (platform, planName, price) => {
         const message = `أهلاً Boostly،\n\nأود طلب الباقة التالية:\n- المنصة: *${platform}*\n- الباقة: *${planName}*\n- السعر: *${price}*\n\nالرجاء تأكيد الطلب.`;
         const encodedMessage = encodeURIComponent(message);
+        if (typeof window !== 'undefined' && window.boostlyAnalytics?.recordOrder) {
+            window.boostlyAnalytics.recordOrder({
+                platform,
+                packageName: planName,
+                price,
+                source: 'قائمة الباقات'
+            });
+        }
         window.open(`https://wa.me/96560930205?text=${encodedMessage}`, '_blank');
     };
 
@@ -602,7 +1013,7 @@ const Footer = () => {
         { icon: Instagram, name: 'instagram', url: 'https://www.instagram.com/boostly_kw?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==' },
         { icon: TikTokIcon, name: 'tiktok', url: 'https://www.tiktok.com/@boostly_kw?_t=ZS-8xXvkGcSE1B&_r=1' },
     ];
-    const navLinks = [{ name: 'الرئيسية', id: 'hero' }, { name: 'الأسعار', id: 'pricing' }, { name: 'الخدمات', id: 'services' }, { name: 'آراء العملاء', id: 'testimonials' }, { name: 'المدونة', id: 'blog' }, { name: 'اتصل بنا', id: 'contact' }];
+    const navLinks = [{ name: 'الرئيسية', id: 'hero' }, { name: 'الأسعار', id: 'pricing' }, { name: 'الخدمات', id: 'services' }, { name: 'لوحة التحكم', id: 'dashboard' }, { name: 'آراء العملاء', id: 'testimonials' }, { name: 'المدونة', id: 'blog' }, { name: 'اتصل بنا', id: 'contact' }];
     const policyLinks = ['سياسة الخصوصية', 'شروط الاستخدام', 'سياسة الاسترداد'];
 
     return (
@@ -723,6 +1134,7 @@ export default function App() {
             <FeaturedPackages />
             <Features />
             <Services />
+            <Dashboard />
             <Pricing />
             <Stats />
             <Testimonials />

--- a/script.js
+++ b/script.js
@@ -1,19 +1,160 @@
-// script.js
-document.addEventListener('DOMContentLoaded', () => {
-    const whatsappNumber = "96512345678"; // <--- تأكد من أن هذا هو رقمك الصحيح
-    const buyButtons = document.querySelectorAll('.buy-button');
-    buyButtons.forEach(button => {
-        button.addEventListener('click', () => {
-            const packageElement = button.closest('.package');
-            const title = packageElement.dataset.title;
-            const price = packageElement.dataset.price;
-            if (title && price) {
-                const message = `مرحباً،\nأرغب في طلب الباقة التالية:\n\n*الباقة:* ${title}\n*السعر:* ${price}\n\nشكراً لك.`;
-                const whatsappUrl = `https://wa.me/${whatsappNumber}?text=${encodeURIComponent(message)}`;
-                window.open(whatsappUrl, '_blank');
-            } else {
-                console.error("لم يتم العثور على بيانات الباقة!");
+// script.js - إدارة تفاعل الطلبات وتحديث بيانات التحليلات
+(function () {
+    const STORAGE_KEY = 'boostly-analytics';
+    const ANALYTICS_URL = '/analytics.json';
+    const WHATSAPP_NUMBER = '96560930205';
+
+    const normalisePrice = (priceText) => {
+        if (typeof priceText === 'number') {
+            return priceText;
+        }
+        if (!priceText) {
+            return 0;
+        }
+        const cleaned = String(priceText).replace(/[^\d.,]/g, '').replace(/,/g, '.');
+        const value = parseFloat(cleaned);
+        return Number.isFinite(value) ? value : 0;
+    };
+
+    const loadAnalyticsFromStorage = () => {
+        try {
+            const stored = window.localStorage.getItem(STORAGE_KEY);
+            return stored ? JSON.parse(stored) : null;
+        } catch (error) {
+            console.warn('تعذر قراءة بيانات التحليلات من التخزين المحلي', error);
+            return null;
+        }
+    };
+
+    const persistAnalytics = (analytics) => {
+        try {
+            window.localStorage.setItem(STORAGE_KEY, JSON.stringify(analytics));
+            window.dispatchEvent(new CustomEvent('analytics-updated', { detail: analytics }));
+        } catch (error) {
+            console.warn('تعذر حفظ بيانات التحليلات', error);
+        }
+    };
+
+    const seedAnalyticsIfNeeded = async () => {
+        if (loadAnalyticsFromStorage()) {
+            return;
+        }
+        try {
+            const response = await fetch(ANALYTICS_URL, { cache: 'no-store' });
+            if (!response.ok) {
+                throw new Error('فشل في تحميل ملف التحليلات المبدئي');
             }
+            const data = await response.json();
+            persistAnalytics(data);
+        } catch (error) {
+            console.warn('تعذر تهيئة بيانات التحليلات المبدئية', error);
+        }
+    };
+
+    const ensureDailyTrendEntry = (analytics, isoDate, label, orderValue) => {
+        analytics.dailyTrends = analytics.dailyTrends || [];
+        const existingEntry = analytics.dailyTrends.find((entry) => entry.date === isoDate);
+        if (existingEntry) {
+            existingEntry.orders = (existingEntry.orders || 0) + 1;
+            existingEntry.visits = (existingEntry.visits || 0) + 3;
+            existingEntry.sales = Number(((existingEntry.sales || 0) + orderValue).toFixed(2));
+        } else {
+            analytics.dailyTrends.push({
+                date: isoDate,
+                label,
+                visits: 3,
+                orders: 1,
+                sales: Number(orderValue.toFixed(2))
+            });
+        }
+        analytics.dailyTrends.sort((a, b) => new Date(a.date) - new Date(b.date));
+        if (analytics.dailyTrends.length > 14) {
+            analytics.dailyTrends = analytics.dailyTrends.slice(-14);
+        }
+    };
+
+    const recordOrder = ({ platform, packageName, price, customerName = 'عميل عبر الموقع', source = 'موقع Boostly' }) => {
+        const analytics = loadAnalyticsFromStorage();
+        if (!analytics) {
+            console.warn('لا توجد بيانات تحليلية لكتابتها، سيتم محاولة تهيئتها أولاً.');
+            seedAnalyticsIfNeeded();
+            return;
+        }
+
+        const priceValue = normalisePrice(price);
+        const now = new Date();
+        const isoDate = now.toISOString().slice(0, 10);
+        const label = now.toLocaleDateString('ar-EG', { day: 'numeric', month: 'short' });
+        const orderId = `ORD-${isoDate.replace(/-/g, '')}-${now.getHours().toString().padStart(2, '0')}${now
+            .getMinutes()
+            .toString()
+            .padStart(2, '0')}`;
+
+        analytics.metrics = analytics.metrics || {};
+        analytics.metrics.orders = (analytics.metrics.orders || 0) + 1;
+        analytics.metrics.sales = Number(((analytics.metrics.sales || 0) + priceValue).toFixed(2));
+        analytics.metrics.visits = (analytics.metrics.visits || 0) + 3;
+        analytics.metrics.avgOrderValue = analytics.metrics.orders
+            ? Number((analytics.metrics.sales / analytics.metrics.orders).toFixed(2))
+            : Number(priceValue.toFixed(2));
+
+        if (analytics.metrics.visits > 0 && analytics.metrics.orders > 0) {
+            analytics.metrics.conversionRate = Number(
+                ((analytics.metrics.orders / analytics.metrics.visits) * 100).toFixed(1)
+            );
+        }
+
+        analytics.recentOrders = analytics.recentOrders || [];
+        analytics.recentOrders = [
+            {
+                id: orderId,
+                customer: customerName,
+                package: `${platform} - ${packageName}`,
+                total: Number(priceValue.toFixed(2)),
+                status: 'قيد المراجعة',
+                statusCode: 'processing',
+                date: now.toLocaleDateString('ar-EG', { year: 'numeric', month: 'long', day: 'numeric' }),
+                source
+            },
+            ...analytics.recentOrders
+        ].slice(0, 8);
+
+        ensureDailyTrendEntry(analytics, isoDate, label, priceValue);
+
+        persistAnalytics(analytics);
+    };
+
+    const attachWhatsAppListeners = () => {
+        const buyButtons = document.querySelectorAll('.buy-button');
+        if (!buyButtons.length) {
+            return;
+        }
+        buyButtons.forEach((button) => {
+            button.addEventListener('click', () => {
+                const packageElement = button.closest('.package');
+                if (!packageElement) {
+                    return;
+                }
+                const title = packageElement.dataset.title || 'باقة مخصصة';
+                const price = packageElement.dataset.price || '0';
+                const platform = packageElement.dataset.platform || 'منصة غير محددة';
+                recordOrder({ platform, packageName: title, price });
+
+                const message = `أهلاً Boostly،\n\nأود طلب الباقة التالية:\n- المنصة: *${platform}*\n- الباقة: *${title}*\n- السعر: *${price}*\n\nالرجاء تأكيد الطلب.`;
+                const whatsappUrl = `https://wa.me/${WHATSAPP_NUMBER}?text=${encodeURIComponent(message)}`;
+                window.open(whatsappUrl, '_blank');
+            });
+        });
+    };
+
+    document.addEventListener('DOMContentLoaded', () => {
+        seedAnalyticsIfNeeded().finally(() => {
+            attachWhatsAppListeners();
         });
     });
-});
+
+    window.boostlyAnalytics = window.boostlyAnalytics || {};
+    window.boostlyAnalytics.recordOrder = recordOrder;
+    window.boostlyAnalytics.getAnalytics = loadAnalyticsFromStorage;
+    window.boostlyAnalytics.persistAnalytics = persistAnalytics;
+})();

--- a/style.css
+++ b/style.css
@@ -20,3 +20,171 @@ footer a { color: #c7a4ff; text-decoration: none; }
 footer a:hover { color: #ffffff; text-decoration: underline; }
 .store-logo { max-height: 100px; margin-bottom: 15px; }
 .snapchat-icon { color: #FFFC00; -webkit-text-stroke: 1px #a9a600; text-stroke: 1px #a9a600; }
+
+/* --- Dashboard Styles --- */
+.dashboard-loading {
+    background: rgba(136, 81, 165, 0.15);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 16px;
+    padding: 32px;
+    text-align: center;
+    color: #e4e2ff;
+    font-size: 1.1rem;
+    box-shadow: 0 18px 36px rgba(136, 81, 165, 0.18);
+}
+
+.dashboard-alert {
+    background: linear-gradient(135deg, rgba(228, 98, 162, 0.18), rgba(246, 153, 128, 0.12));
+    border: 1px solid rgba(228, 98, 162, 0.35);
+    padding: 18px 22px;
+    border-radius: 14px;
+    color: #ffe7f3;
+    box-shadow: 0 15px 30px rgba(228, 98, 162, 0.18);
+}
+
+.metric-card {
+    background: linear-gradient(160deg, rgba(255, 255, 255, 0.08) 0%, rgba(255, 255, 255, 0.02) 100%);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 20px;
+    padding: 26px;
+    box-shadow: 0 20px 40px rgba(23, 14, 57, 0.35);
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+    position: relative;
+    overflow: hidden;
+}
+
+.metric-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: radial-gradient(circle at top right, rgba(228, 98, 162, 0.28), transparent 55%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.metric-card:hover {
+    transform: translateY(-8px);
+    box-shadow: 0 22px 44px rgba(136, 81, 165, 0.25);
+}
+
+.metric-card:hover::after {
+    opacity: 1;
+}
+
+.metric-icon {
+    width: 48px;
+    height: 48px;
+    border-radius: 14px;
+    display: grid;
+    place-items: center;
+    background: linear-gradient(135deg, rgba(136, 81, 165, 0.25), rgba(228, 98, 162, 0.2));
+    color: #ffffff;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
+}
+
+.dashboard-panel {
+    background: linear-gradient(160deg, rgba(25, 17, 60, 0.9) 0%, rgba(25, 17, 60, 0.65) 100%);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 22px;
+    padding: 28px;
+    box-shadow: 0 24px 48px rgba(14, 9, 38, 0.45);
+    backdrop-filter: blur(12px);
+}
+
+.dashboard-table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0 12px;
+    color: #f9f7ff;
+}
+
+.dashboard-table thead th {
+    text-align: right;
+    font-weight: 700;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: rgba(255, 255, 255, 0.68);
+    padding-bottom: 12px;
+}
+
+.dashboard-table tbody tr {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 14px 30px rgba(17, 11, 45, 0.35);
+}
+
+.dashboard-table tbody td {
+    padding: 18px 16px;
+    font-size: 0.95rem;
+    color: rgba(255, 255, 255, 0.9);
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.dashboard-table tbody tr:first-child td {
+    border-top: none;
+}
+
+.dashboard-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.status-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 6px 14px;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+}
+
+.status-completed {
+    background: rgba(16, 185, 129, 0.15);
+    color: #6ee7b7;
+    border: 1px solid rgba(16, 185, 129, 0.4);
+}
+
+.status-processing {
+    background: rgba(59, 130, 246, 0.15);
+    color: #93c5fd;
+    border: 1px solid rgba(59, 130, 246, 0.35);
+}
+
+.status-pending {
+    background: rgba(234, 179, 8, 0.15);
+    color: #facc15;
+    border: 1px solid rgba(234, 179, 8, 0.35);
+}
+
+.status-cancelled {
+    background: rgba(248, 113, 113, 0.18);
+    color: #fecaca;
+    border: 1px solid rgba(248, 113, 113, 0.35);
+}
+
+.traffic-source {
+    padding: 16px 18px;
+    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 14px 30px rgba(20, 15, 45, 0.35);
+}
+
+.traffic-progress {
+    height: 8px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.12);
+    overflow: hidden;
+    margin-bottom: 8px;
+}
+
+.traffic-progress-bar {
+    height: 100%;
+    background: linear-gradient(90deg, #8851a5 0%, #e462a2 60%, #f69980 100%);
+    border-radius: inherit;
+}


### PR DESCRIPTION
## Summary
- add a dashboard section with metric cards, charts, and recent orders backed by a shared analytics store
- seed the application with analytics.json and extend styling to cover dashboard widgets
- persist new WhatsApp orders from React flows and legacy buttons into the analytics store for live updates

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68cfb7cc5a688320a3022e973c87fa9c